### PR TITLE
Fix/account property view text fields

### DIFF
--- a/RssReader/Controller/Login/AccountPropertyViewController.swift
+++ b/RssReader/Controller/Login/AccountPropertyViewController.swift
@@ -78,6 +78,11 @@ class AccountPropertyViewController: UIViewController, Transitioner {
         validation()
     }
     
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        validation()
+        view.endEditing(true)
+    }
+    
     @objc func close() {
         dismiss(animated: true)
     }

--- a/RssReader/View/Login/AccountProperty.storyboard
+++ b/RssReader/View/Login/AccountProperty.storyboard
@@ -132,6 +132,7 @@
                         <outlet property="mailTextField" destination="lcB-yU-zwe" id="Leb-qa-r89"/>
                         <outlet property="passwordTextField" destination="6aC-rm-myL" id="39q-eL-ccH"/>
                         <outlet property="profileImageButton" destination="XeI-on-Fjs" id="iOc-BY-46a"/>
+                        <outlet property="stackViewCenterY" destination="Ego-fB-dMl" id="vtg-6N-vSh"/>
                         <outlet property="usernameTextField" destination="u4i-Cc-qRu" id="1u3-XN-2eK"/>
                     </connections>
                 </viewController>

--- a/RssReader/View/Login/AccountProperty.storyboard
+++ b/RssReader/View/Login/AccountProperty.storyboard
@@ -66,7 +66,7 @@
                                                     <textField opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" borderStyle="roundedRect" textAlignment="natural" minimumFontSize="17" translatesAutoresizingMaskIntoConstraints="NO" id="6aC-rm-myL">
                                                         <rect key="frame" x="0.0" y="20.5" width="300" height="34"/>
                                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
-                                                        <textInputTraits key="textInputTraits"/>
+                                                        <textInputTraits key="textInputTraits" secureTextEntry="YES"/>
                                                         <connections>
                                                             <action selector="passwordTextFieldTappedDone:" destination="LXO-Ef-2su" eventType="editingDidEndOnExit" id="yFj-Fb-Ni1"/>
                                                         </connections>

--- a/RssReaderTests/LoginViewTests.swift
+++ b/RssReaderTests/LoginViewTests.swift
@@ -33,7 +33,7 @@ class LoginViewTests: XCTestCase {
         }
     }
     
-    // 8文字で英数字を含むケース
+    // 8文字で英数字以外を含むケース
     func testValidId_returnAlphaNumericError() throws {
         let testLoginView = LoginViewController()
         let sevenString = "1234567"


### PR DESCRIPTION
- キーボードでテキストフィールドが隠れる不具合を修正しました。
- 任意の箇所をタップするとキーボードが閉じる挙動を追加しました。
- アカウント詳細画面のパスワードをSecureTextEntry = trueに変更しました。