### PR TITLE
fix: 記事タイプ毎にソートできるように修正

### DIFF
--- a/RssReader/Model/ArticleList.swift
+++ b/RssReader/Model/ArticleList.swift
@@ -38,6 +38,9 @@ struct Article {
     var read: Bool = false
     var laterRead: Bool = false
     var isStar: Bool = false
+    var sortKey: String {
+        return rssFeedTitle + tag + (item.pubDate?.description ?? "") + item.link
+    }
 }
 
 class RealmArticle: Object {

--- a/RssReader/Model/FilterModel.swift
+++ b/RssReader/Model/FilterModel.swift
@@ -72,9 +72,9 @@ extension FilterModelProtocol {
             }
         case .rssFeedType:
             if orderByDesc {
-                return sortedList.keys.sorted { sortedList[$0]!.rssFeedTitle + sortedList[$0]!.tag > sortedList[$1]!.rssFeedTitle + sortedList[$1]!.tag}
+                return sortedList.keys.sorted { sortedList[$0]!.sortKey > sortedList[$1]!.sortKey}
             } else {
-                return sortedList.keys.sorted { sortedList[$0]!.rssFeedTitle + sortedList[$0]!.tag < sortedList[$1]!.rssFeedTitle + sortedList[$1]!.tag}
+                return sortedList.keys.sorted { sortedList[$0]!.sortKey < sortedList[$1]!.sortKey}
             }
         }
     }

--- a/RssReader/Model/FilterModel.swift
+++ b/RssReader/Model/FilterModel.swift
@@ -72,9 +72,9 @@ extension FilterModelProtocol {
             }
         case .rssFeedType:
             if orderByDesc {
-                return sortedList.keys.sorted { $0 > $1}
+                return sortedList.keys.sorted { sortedList[$0]!.rssFeedTitle + sortedList[$0]!.tag > sortedList[$1]!.rssFeedTitle + sortedList[$1]!.tag}
             } else {
-                return sortedList.keys.sorted { $0 < $1}
+                return sortedList.keys.sorted { sortedList[$0]!.rssFeedTitle + sortedList[$0]!.tag < sortedList[$1]!.rssFeedTitle + sortedList[$1]!.tag}
             }
         }
     }


### PR DESCRIPTION
記事タイトルとタグ名を繋いだ文字列でソートすることで解決しました。