### PR TITLE
Feature/make web api client

### DIFF
--- a/RssReader.xcodeproj/project.pbxproj
+++ b/RssReader.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		0925C85426536D7E006401C1 /* Extension_UITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C85326536D7E006401C1 /* Extension_UITableViewCell.swift */; };
 		0925C85626538325006401C1 /* RssClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C85526538325006401C1 /* RssClientTests.swift */; };
 		0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A426575EB4006401C1 /* WebAPITests.swift */; };
+		0925C8A72657606E006401C1 /* WebAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A62657606E006401C1 /* WebAPI.swift */; };
 		092B65BB26316655002799AD /* FilterMenuViewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65BA26316655002799AD /* FilterMenuViewPage.swift */; };
 		092B65C326316E46002799AD /* FilterMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65C226316E46002799AD /* FilterMenuUITests.swift */; };
 		095F95F225985F52007DC2D5 /* SelectRssFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */; };
@@ -174,6 +175,7 @@
 		0925C85326536D7E006401C1 /* Extension_UITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension_UITableViewCell.swift; sourceTree = "<group>"; };
 		0925C85526538325006401C1 /* RssClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssClientTests.swift; sourceTree = "<group>"; };
 		0925C8A426575EB4006401C1 /* WebAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPITests.swift; sourceTree = "<group>"; };
+		0925C8A62657606E006401C1 /* WebAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPI.swift; sourceTree = "<group>"; };
 		092B65BA26316655002799AD /* FilterMenuViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuViewPage.swift; sourceTree = "<group>"; };
 		092B65C226316E46002799AD /* FilterMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuUITests.swift; sourceTree = "<group>"; };
 		095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectRssFeedViewController.swift; sourceTree = "<group>"; };
@@ -358,6 +360,7 @@
 		0925C8A326575B43006401C1 /* WebAPI */ = {
 			isa = PBXGroup;
 			children = (
+				0925C8A62657606E006401C1 /* WebAPI.swift */,
 			);
 			path = WebAPI;
 			sourceTree = "<group>";
@@ -948,6 +951,7 @@
 				095FDBEC25A754E2007C8922 /* CommonRouter.swift in Sources */,
 				0912527D25E87E8700F9CFCA /* RssFeedDisplayTableViewCell.swift in Sources */,
 				096A1AA625D7CC8300EBC589 /* RssFeed.swift in Sources */,
+				0925C8A72657606E006401C1 /* WebAPI.swift in Sources */,
 				09902EFA2611084300B2B9A0 /* MailLoginViewController.swift in Sources */,
 				0912525A25E7F68000F9CFCA /* ContainReadTableViewCell.swift in Sources */,
 				0975611725B2985A007B0D3F /* DummyRouter.swift in Sources */,

--- a/RssReader.xcodeproj/project.pbxproj
+++ b/RssReader.xcodeproj/project.pbxproj
@@ -42,6 +42,7 @@
 		0925C8A72657606E006401C1 /* WebAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A62657606E006401C1 /* WebAPI.swift */; };
 		0925C8A926578BCB006401C1 /* RssAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A826578BCB006401C1 /* RssAPI.swift */; };
 		0925C8AB26579353006401C1 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8AA26579353006401C1 /* Either.swift */; };
+		0925C8AF265B77D3006401C1 /* RssArticleListTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8AE265B77D3006401C1 /* RssArticleListTests.swift */; };
 		092B65BB26316655002799AD /* FilterMenuViewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65BA26316655002799AD /* FilterMenuViewPage.swift */; };
 		092B65C326316E46002799AD /* FilterMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65C226316E46002799AD /* FilterMenuUITests.swift */; };
 		095F95F225985F52007DC2D5 /* SelectRssFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */; };
@@ -180,6 +181,7 @@
 		0925C8A62657606E006401C1 /* WebAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPI.swift; sourceTree = "<group>"; };
 		0925C8A826578BCB006401C1 /* RssAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssAPI.swift; sourceTree = "<group>"; };
 		0925C8AA26579353006401C1 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
+		0925C8AE265B77D3006401C1 /* RssArticleListTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssArticleListTests.swift; sourceTree = "<group>"; };
 		092B65BA26316655002799AD /* FilterMenuViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuViewPage.swift; sourceTree = "<group>"; };
 		092B65C226316E46002799AD /* FilterMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuUITests.swift; sourceTree = "<group>"; };
 		095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectRssFeedViewController.swift; sourceTree = "<group>"; };
@@ -636,6 +638,7 @@
 				09B803352590CF9300CA2D19 /* Info.plist */,
 				0925C85526538325006401C1 /* RssClientTests.swift */,
 				0925C8A426575EB4006401C1 /* WebAPITests.swift */,
+				0925C8AE265B77D3006401C1 /* RssArticleListTests.swift */,
 			);
 			path = RssReaderTests;
 			sourceTree = "<group>";
@@ -1014,6 +1017,7 @@
 				09902F77261AFCF800B2B9A0 /* LoginViewTests.swift in Sources */,
 				09B803342590CF9300CA2D19 /* RssReaderTests.swift in Sources */,
 				0925C85626538325006401C1 /* RssClientTests.swift in Sources */,
+				0925C8AF265B77D3006401C1 /* RssArticleListTests.swift in Sources */,
 				0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RssReader.xcodeproj/project.pbxproj
+++ b/RssReader.xcodeproj/project.pbxproj
@@ -40,6 +40,7 @@
 		0925C85626538325006401C1 /* RssClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C85526538325006401C1 /* RssClientTests.swift */; };
 		0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A426575EB4006401C1 /* WebAPITests.swift */; };
 		0925C8A72657606E006401C1 /* WebAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A62657606E006401C1 /* WebAPI.swift */; };
+		0925C8A926578BCB006401C1 /* RssAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A826578BCB006401C1 /* RssAPI.swift */; };
 		092B65BB26316655002799AD /* FilterMenuViewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65BA26316655002799AD /* FilterMenuViewPage.swift */; };
 		092B65C326316E46002799AD /* FilterMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65C226316E46002799AD /* FilterMenuUITests.swift */; };
 		095F95F225985F52007DC2D5 /* SelectRssFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */; };
@@ -176,6 +177,7 @@
 		0925C85526538325006401C1 /* RssClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssClientTests.swift; sourceTree = "<group>"; };
 		0925C8A426575EB4006401C1 /* WebAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPITests.swift; sourceTree = "<group>"; };
 		0925C8A62657606E006401C1 /* WebAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPI.swift; sourceTree = "<group>"; };
+		0925C8A826578BCB006401C1 /* RssAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssAPI.swift; sourceTree = "<group>"; };
 		092B65BA26316655002799AD /* FilterMenuViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuViewPage.swift; sourceTree = "<group>"; };
 		092B65C226316E46002799AD /* FilterMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuUITests.swift; sourceTree = "<group>"; };
 		095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectRssFeedViewController.swift; sourceTree = "<group>"; };
@@ -361,6 +363,7 @@
 			isa = PBXGroup;
 			children = (
 				0925C8A62657606E006401C1 /* WebAPI.swift */,
+				0925C8A826578BCB006401C1 /* RssAPI.swift */,
 			);
 			path = WebAPI;
 			sourceTree = "<group>";
@@ -991,6 +994,7 @@
 				091251DC25E629E800F9CFCA /* ArticleDetailViewController.swift in Sources */,
 				099BB88F25DCDAA8003AF947 /* SettingViewController.swift in Sources */,
 				098D56C1259375BC00EAD41F /* Transitioner.swift in Sources */,
+				0925C8A926578BCB006401C1 /* RssAPI.swift in Sources */,
 				0925C85426536D7E006401C1 /* Extension_UITableViewCell.swift in Sources */,
 				096A1AAD25D7CD9A00EBC589 /* QiitaType.swift in Sources */,
 				097AFF9F25C07736007AC6FA /* ArticleListRouter.swift in Sources */,

--- a/RssReader.xcodeproj/project.pbxproj
+++ b/RssReader.xcodeproj/project.pbxproj
@@ -41,6 +41,7 @@
 		0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A426575EB4006401C1 /* WebAPITests.swift */; };
 		0925C8A72657606E006401C1 /* WebAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A62657606E006401C1 /* WebAPI.swift */; };
 		0925C8A926578BCB006401C1 /* RssAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A826578BCB006401C1 /* RssAPI.swift */; };
+		0925C8AB26579353006401C1 /* Either.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8AA26579353006401C1 /* Either.swift */; };
 		092B65BB26316655002799AD /* FilterMenuViewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65BA26316655002799AD /* FilterMenuViewPage.swift */; };
 		092B65C326316E46002799AD /* FilterMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65C226316E46002799AD /* FilterMenuUITests.swift */; };
 		095F95F225985F52007DC2D5 /* SelectRssFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */; };
@@ -178,6 +179,7 @@
 		0925C8A426575EB4006401C1 /* WebAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPITests.swift; sourceTree = "<group>"; };
 		0925C8A62657606E006401C1 /* WebAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPI.swift; sourceTree = "<group>"; };
 		0925C8A826578BCB006401C1 /* RssAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssAPI.swift; sourceTree = "<group>"; };
+		0925C8AA26579353006401C1 /* Either.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Either.swift; sourceTree = "<group>"; };
 		092B65BA26316655002799AD /* FilterMenuViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuViewPage.swift; sourceTree = "<group>"; };
 		092B65C226316E46002799AD /* FilterMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuUITests.swift; sourceTree = "<group>"; };
 		095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectRssFeedViewController.swift; sourceTree = "<group>"; };
@@ -364,6 +366,7 @@
 			children = (
 				0925C8A62657606E006401C1 /* WebAPI.swift */,
 				0925C8A826578BCB006401C1 /* RssAPI.swift */,
+				0925C8AA26579353006401C1 /* Either.swift */,
 			);
 			path = WebAPI;
 			sourceTree = "<group>";
@@ -997,6 +1000,7 @@
 				0925C8A926578BCB006401C1 /* RssAPI.swift in Sources */,
 				0925C85426536D7E006401C1 /* Extension_UITableViewCell.swift in Sources */,
 				096A1AAD25D7CD9A00EBC589 /* QiitaType.swift in Sources */,
+				0925C8AB26579353006401C1 /* Either.swift in Sources */,
 				097AFF9F25C07736007AC6FA /* ArticleListRouter.swift in Sources */,
 				09ACE21C25964E4500FDB597 /* UserConfig.swift in Sources */,
 				0912526925E8087D00F9CFCA /* OrderByTableViewCell.swift in Sources */,

--- a/RssReader.xcodeproj/project.pbxproj
+++ b/RssReader.xcodeproj/project.pbxproj
@@ -38,6 +38,7 @@
 		0925C852265255E6006401C1 /* Colors.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 0925C851265255E6006401C1 /* Colors.xcassets */; };
 		0925C85426536D7E006401C1 /* Extension_UITableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C85326536D7E006401C1 /* Extension_UITableViewCell.swift */; };
 		0925C85626538325006401C1 /* RssClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C85526538325006401C1 /* RssClientTests.swift */; };
+		0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0925C8A426575EB4006401C1 /* WebAPITests.swift */; };
 		092B65BB26316655002799AD /* FilterMenuViewPage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65BA26316655002799AD /* FilterMenuViewPage.swift */; };
 		092B65C326316E46002799AD /* FilterMenuUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 092B65C226316E46002799AD /* FilterMenuUITests.swift */; };
 		095F95F225985F52007DC2D5 /* SelectRssFeedViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */; };
@@ -172,6 +173,7 @@
 		0925C851265255E6006401C1 /* Colors.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Colors.xcassets; sourceTree = "<group>"; };
 		0925C85326536D7E006401C1 /* Extension_UITableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Extension_UITableViewCell.swift; sourceTree = "<group>"; };
 		0925C85526538325006401C1 /* RssClientTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RssClientTests.swift; sourceTree = "<group>"; };
+		0925C8A426575EB4006401C1 /* WebAPITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WebAPITests.swift; sourceTree = "<group>"; };
 		092B65BA26316655002799AD /* FilterMenuViewPage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuViewPage.swift; sourceTree = "<group>"; };
 		092B65C226316E46002799AD /* FilterMenuUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FilterMenuUITests.swift; sourceTree = "<group>"; };
 		095F95F125985F52007DC2D5 /* SelectRssFeedViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectRssFeedViewController.swift; sourceTree = "<group>"; };
@@ -353,6 +355,13 @@
 			path = Article;
 			sourceTree = "<group>";
 		};
+		0925C8A326575B43006401C1 /* WebAPI */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = WebAPI;
+			sourceTree = "<group>";
+		};
 		092B65B926316628002799AD /* FilterMenu */ = {
 			isa = PBXGroup;
 			children = (
@@ -441,6 +450,7 @@
 				0975613E25B73155007B0D3F /* ArticleList.swift */,
 				0975614325B731CF007B0D3F /* RssClient.swift */,
 				0912521025E68D1300F9CFCA /* FilterModel.swift */,
+				0925C8A326575B43006401C1 /* WebAPI */,
 				096A1AAA25D7CD6000EBC589 /* RssFeed */,
 			);
 			path = Model;
@@ -616,6 +626,7 @@
 				09902F76261AFCF800B2B9A0 /* LoginViewTests.swift */,
 				09B803352590CF9300CA2D19 /* Info.plist */,
 				0925C85526538325006401C1 /* RssClientTests.swift */,
+				0925C8A426575EB4006401C1 /* WebAPITests.swift */,
 			);
 			path = RssReaderTests;
 			sourceTree = "<group>";
@@ -991,6 +1002,7 @@
 				09902F77261AFCF800B2B9A0 /* LoginViewTests.swift in Sources */,
 				09B803342590CF9300CA2D19 /* RssReaderTests.swift in Sources */,
 				0925C85626538325006401C1 /* RssClientTests.swift in Sources */,
+				0925C8A526575EB4006401C1 /* WebAPITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RssReader/Model/RssFeed/RssFeed.swift
+++ b/RssReader/Model/RssFeed/RssFeed.swift
@@ -75,25 +75,47 @@ extension RssFeed: RssFeedProtocol {
         }
     }
     
+    // WebAPIおよびRssArticleListリプレイス前のコード
+//    func fetchArticle2(completion: @escaping ([String: Article]?) -> Void){
+//        // RssClientの別スレっっどの処理中にRealmObject(今回はself)にアクセスできないため別名の変数をこの関数内で保持しておきます。
+//        let myTag = self.tag
+//        let myTitle = self.title
+//        let myUrl = self.url
+//        let myFaviconUrl = self.faviconUrl
+//        RssClient.fetchItems(rssApiUrl: url) { (response) in
+//            var articles: [String: Article] = [:]
+//            guard let items = response else {
+//                completion(nil)
+//                return
+//            }
+//            for item in items {
+//                if !CommonData.rssFeedListModel.articleList.keys.contains(item.link) {
+//                    articles[item.link] = Article(item: item, rssFeedTitle: myTitle, rssFeedUrl: myUrl, rssFeedFaviconUrl: myFaviconUrl, tag: myTag)
+//                }
+//            }
+//            completion(articles)
+//        }
+//    }
     
     func fetchArticle(completion: @escaping ([String: Article]?) -> Void){
-        // RssClientの別スレっっどの処理中にRealmObject(今回はself)にアクセスできないため別名の変数をこの関数内で保持しておきます。
         let myTag = self.tag
         let myTitle = self.title
         let myUrl = self.url
         let myFaviconUrl = self.faviconUrl
-        RssClient.fetchItems(rssApiUrl: url) { (response) in
-            var articles: [String: Article] = [:]
-            guard let items = response else {
+        RssArticleList.fetch(urlString: url) { (errorOrArticle) in
+            switch errorOrArticle {
+            case let .left(error):
+                print(error)
                 completion(nil)
-                return
-            }
-            for item in items {
-                if !CommonData.rssFeedListModel.articleList.keys.contains(item.link) {
-                    articles[item.link] = Article(item: item, rssFeedTitle: myTitle, rssFeedUrl: myUrl, rssFeedFaviconUrl: myFaviconUrl, tag: myTag)
+            case let .right(articleList):
+                var articles: [String: Article] = [:]
+                for item in articleList.items {
+                    if !CommonData.rssFeedListModel.articleList.keys.contains(item.link) {
+                        articles[item.link] = Article(item: item, rssFeedTitle: myTitle, rssFeedUrl: myUrl, rssFeedFaviconUrl: myFaviconUrl, tag: myTag)
+                    }
                 }
+                completion(articles)
             }
-            completion(articles)
         }
     }
 }

--- a/RssReader/Model/RssFeed/RssFeed.swift
+++ b/RssReader/Model/RssFeed/RssFeed.swift
@@ -77,7 +77,7 @@ extension RssFeed: RssFeedProtocol {
     
     // WebAPIおよびRssArticleListリプレイス前のコード
 //    func fetchArticle2(completion: @escaping ([String: Article]?) -> Void){
-//        // RssClientの別スレっっどの処理中にRealmObject(今回はself)にアクセスできないため別名の変数をこの関数内で保持しておきます。
+//        // RssClientの別スレッドの処理中にRealmObject(今回はself)にアクセスできないため別名の変数をこの関数内で保持しておきます。
 //        let myTag = self.tag
 //        let myTitle = self.title
 //        let myUrl = self.url

--- a/RssReader/Model/RssFeed/RssFeed.swift
+++ b/RssReader/Model/RssFeed/RssFeed.swift
@@ -97,6 +97,7 @@ extension RssFeed: RssFeedProtocol {
 //        }
 //    }
     
+    /// WebAPI, RssArticleListを使った実装です。
     func fetchArticle(completion: @escaping ([String: Article]?) -> Void){
         let myTag = self.tag
         let myTitle = self.title

--- a/RssReader/Model/RssFeed/RssFeedListModel.swift
+++ b/RssReader/Model/RssFeed/RssFeedListModel.swift
@@ -122,8 +122,8 @@ class RssFeedListModel: RssFeedListModelProtocol {
         self.rssFeedListModelDelegate = rssFeedListModelDelegate
         loadCounter = rssFeedList.count
         let rssFeeds = rssFeedList
-        for key in rssFeeds.keys {
-            rssFeeds[key]!.fetchArticle { (articles) in
+        for rssFeed in rssFeeds.values {
+            rssFeed.fetchArticle { (articles) in
                 if let articleList = articles {
                     self.articleList += articleList // extensionで辞書の足し算をできるようにしてます。
                 }

--- a/RssReader/Model/WebAPI/Either.swift
+++ b/RssReader/Model/WebAPI/Either.swift
@@ -11,10 +11,10 @@ import Foundation
 /// たとえば、Either<String, Int> は文字列か整数のどちらかを意味する。
 /// なお、慣例的にどちらの型かを左右で表現することが多い。
 enum Either<Left, Right> {
-    /// Eigher<A, B> の A の方の型。
+    /// Either<A, B> の A の方の型。
     case left(Left)
 
-    /// Eigher<A, B> の B の方の型。
+    /// Either<A, B> の B の方の型。
     case right(Right)
 
 

--- a/RssReader/Model/WebAPI/Either.swift
+++ b/RssReader/Model/WebAPI/Either.swift
@@ -17,7 +17,6 @@ enum Either<Left, Right> {
     /// Either<A, B> の B の方の型。
     case right(Right)
 
-
     /// もし、左側の型ならその値を、右側の型なら nil を返す。
     var left: Left? {
         switch self {

--- a/RssReader/Model/WebAPI/Either.swift
+++ b/RssReader/Model/WebAPI/Either.swift
@@ -1,0 +1,42 @@
+//
+//  Either.swift
+//  RssReader
+//
+//  Created by 若江照仁 on 2021/05/21.
+//
+
+import Foundation
+
+/// 型 A か型 B のどちらかのオブジェクトを表す型。
+/// たとえば、Either<String, Int> は文字列か整数のどちらかを意味する。
+/// なお、慣例的にどちらの型かを左右で表現することが多い。
+enum Either<Left, Right> {
+    /// Eigher<A, B> の A の方の型。
+    case left(Left)
+
+    /// Eigher<A, B> の B の方の型。
+    case right(Right)
+
+
+    /// もし、左側の型ならその値を、右側の型なら nil を返す。
+    var left: Left? {
+        switch self {
+        case let .left(x):
+            return x
+
+        case .right:
+            return nil
+        }
+    }
+
+    /// もし、右側の型ならその値を、左側の型なら nil を返す。
+    var right: Right? {
+        switch self {
+        case .left:
+            return nil
+
+        case let .right(x):
+            return x
+        }
+    }
+}

--- a/RssReader/Model/WebAPI/RssAPI.swift
+++ b/RssReader/Model/WebAPI/RssAPI.swift
@@ -77,6 +77,7 @@ struct RssArticleList: Codable {
             }
         }
     }
+    
     /// Rss API の変換で起きうるエラーの一覧。
     enum TransformError {
         /// HTTP ステータスコードが OK 以外だった場合のエラー。

--- a/RssReader/Model/WebAPI/RssAPI.swift
+++ b/RssReader/Model/WebAPI/RssAPI.swift
@@ -28,9 +28,19 @@ struct RssArticle {
     /// このような、「どちらか」を意味する Either という型で表現する。
     /// Self が左でなく右なのは、正しいと Right をかけた慣例。
     static func from(response: Response) -> Either<TransformError, Self> {
-        // TODO
+        switch response.statusCode {
+        case .ok:
+            guard let title = String(data: response.payload, encoding: .utf8) else {
+                // エンコード失敗の場合は.malformedDataとしてエラーメッセージを流す。
+                return .left(.malformedData(debugInfo: "not UTF-8 String"))
+            }
+            let item = Item(title: title, pubDate: "", link: "", guid: "")
+            return Either.right(RssArticle(item: item, rssFeedTitle: "", rssFeedUrl: "", rssFeedFaviconUrl: "", tag: ""))
+        default:
+            return Either.left(.unexpectedStatusCode(debugInfo: "\(response.statusCode)")
+            )
+        }
     }
-    
     
     /// Rss API の変換で起きうるエラーの一覧。
     enum TransformError {

--- a/RssReader/Model/WebAPI/RssAPI.swift
+++ b/RssReader/Model/WebAPI/RssAPI.swift
@@ -57,24 +57,21 @@ struct RssArticleList: Codable {
             methodAndPayload: .get
         )
         
-        // GitHub Zen API を呼び出す。
-        WebAPI.call(with: input) { output in
+        // Alamofireの方の実装をしています。
+        WebAPI.callByAF(with: input) { output in
             switch output {
             case let .noResponse(connectionError):
                 // 接続エラーの場合は、接続エラーを渡す。
                 block(.left(.left(connectionError)))
                 
             case let .hasResponse(response):
-                // レスポンスがわかりやすくなるように GitHubZen へと変換する。
                 let errorOrZen = from(response: response)
                 
                 switch errorOrZen {
                 case let .left(error):
-                    // 変換エラーの場合は、変換エラーを渡す。
                     block(.left(.right(error)))
                     
                 case let .right(article):
-                    // 正常に変換できた場合は、GitHubZen オブジェクトを渡す。
                     block(.right(article))
                 }
             }

--- a/RssReader/Model/WebAPI/RssAPI.swift
+++ b/RssReader/Model/WebAPI/RssAPI.swift
@@ -21,4 +21,23 @@ struct RssArticle {
     var sortKey: String {
         return rssFeedTitle + tag + (item.pubDate?.description ?? "") + item.link
     }
+    /// レスポンスからわかりやすいオブジェクトへと変換する関数。
+    ///
+    /// ただし、サーバーがエラーを返してきた場合などは変換できないので、
+    /// その場合はエラーを返す。つまり、戻り値はエラーがわかりやすいオブジェクトになる。
+    /// このような、「どちらか」を意味する Either という型で表現する。
+    /// Self が左でなく右なのは、正しいと Right をかけた慣例。
+    static func from(response: Response) -> Either<TransformError, Self> {
+        // TODO
+    }
+    
+    
+    /// Rss API の変換で起きうるエラーの一覧。
+    enum TransformError {
+        /// HTTP ステータスコードが OK 以外だった場合のエラー。
+        case unexpectedStatusCode(debugInfo: String)
+        
+        /// ペイロードが壊れた文字列だった場合のエラー。
+        case malformedData(debugInfo: String)
+    }
 }

--- a/RssReader/Model/WebAPI/RssAPI.swift
+++ b/RssReader/Model/WebAPI/RssAPI.swift
@@ -1,0 +1,24 @@
+//
+//  RssAPI.swift
+//  RssReader
+//
+//  Created by 若江照仁 on 2021/05/21.
+//
+
+import Foundation
+
+/// 既存のArticleList, Feed, Itemは利用して
+/// Articleを書き換えます。一旦コピーします。
+struct RssArticle {
+    let item: Item
+    let rssFeedTitle: String
+    let rssFeedUrl: String
+    let rssFeedFaviconUrl: String
+    let tag: String
+    var read: Bool = false
+    var laterRead: Bool = false
+    var isStar: Bool = false
+    var sortKey: String {
+        return rssFeedTitle + tag + (item.pubDate?.description ?? "") + item.link
+    }
+}

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -208,12 +208,12 @@ enum WebAPI {
          
         let headers = HTTPHeaders(input.headers)
         
-        
         AF.request(input.url, method: method, headers: headers).response { response in
             let output = createOutput(data: response.data, urlResponse: response.response, error: response.error)
             block(output)
         }.resume()
     }
+    
     // ビルドを通すために callByAF 関数を用意しておく。
     static func callByAF(with input: Input) {
         self.call(with: input) { _ in

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -74,6 +74,9 @@ enum Output {
 enum ConnectionError {
     /// データまたはレスポンスが存在しない場合のエラー。
     case noDataOrNoResponse(debugInfo: String)
+    
+    /// 不正な URL の場合のエラー。
+    case malformedURL(debugInfo: String)
 }
 
 /// API のレスポンス。構成要素は、以下の3つ。

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
+// MARK:- Input
 /// API への入力は Request そのもの。
 typealias Input = Request
-
 
 /// Request は以下の要素から構成される:
 typealias Request = (
@@ -27,7 +27,6 @@ typealias Request = (
     /// 表現するために、後述する enum を使っている。
     methodAndPayload: HTTPMethodAndPayload
 )
-
 
 /// HTTP メソッドとペイロードの組み合わせ。
 enum HTTPMethodAndPayload {
@@ -59,6 +58,66 @@ enum HTTPMethodAndPayload {
     }
 }
 
+// MARK:- Output
+/// API の出力にをあらわす enum。
+/// API の出力でありえるのは、
+enum Output {
+    /// レスポンスがある場合か、
+    case hasResponse(Response)
+
+    /// 通信エラーでレスポンスがない場合。
+    case noResponse(ConnectionError)
+}
+
+/// 通信エラー。
+enum ConnectionError {
+    /// データまたはレスポンスが存在しない場合のエラー。
+    case noDataOrNoResponse(debugInfo: String)
+}
+
+/// API のレスポンス。構成要素は、以下の3つ。
+typealias Response = (
+    /// レスポンスの意味をあらわすステータスコード。
+    statusCode: HTTPStatus,
+
+    /// HTTP ヘッダー。
+    headers: [String: String],
+
+    /// レスポンスの本文。
+    payload: Data
+)
+
+/// HTTPステータスコードを読みやすくする型。
+enum HTTPStatus {
+    /// OK の場合。HTTP ステータスコードでは 200 にあたる。
+    case ok
+
+    /// OK ではなかった場合の例。
+    /// notFound の HTTP ステータスコードは 404 で、
+    /// リクエストで要求された項目が存在しなかったことを意味する。
+    case notFound
+
+    /// 他にもステータスコードはあるが、全部定義するのは面倒なので、
+    /// 必要ペースで定義できるようにする。
+    case unsupported(code: Int)
+
+    /// HTTP ステータスコードから HTTPステータス型を作る関数。
+    static func from(code: Int) -> HTTPStatus {
+        switch code {
+        case 200:
+            // 200 は OK の意味。
+            return .ok
+        case 404:
+            // 404 は notFound の意味。
+            return .notFound
+        default:
+            // それ以外はまだ対応しない。
+            return .unsupported(code: code)
+        }
+    }
+}
+
+// MARK:- WebAPI
 enum WebAPI {
     // ビルドを通すために call 関数を用意しておく。
     static func call(with input: Input) {

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -1,0 +1,56 @@
+//
+//  WebAPI.swift
+//  RssReader
+//
+//  Created by 若江照仁 on 2021/05/21.
+//
+
+import Foundation
+
+/// API への入力は Request そのもの。
+typealias Input = Request
+
+
+/// Request は以下の要素から構成される:
+typealias Request = (
+    /// リクエストの向き先の URL。
+    url: URL,
+
+    /// クエリ文字列。クエリは URLQueryItem という標準のクラスを使っている。
+    queries: [URLQueryItem],
+
+    /// HTTP ヘッダー。ヘッダー名と値の辞書になっている。
+    headers: [String: String],
+
+    /// HTTP メソッドとペイロードの組み合わせ。
+    /// GET にはペイロードがなく、PUT や POST にはペイロードがあることを
+    /// 表現するために、後述する enum を使っている。
+    methodAndPayload: HTTPMethodAndPayload
+)
+
+
+/// HTTP メソッドとペイロードの組み合わせ。
+enum HTTPMethodAndPayload {
+    /// GET メソッドの定義。
+    case get
+
+    /// POST メソッドの定義（必要になるまでは省略）。
+    // case post(payload: Data?)
+
+    /// メソッドの文字列表現。
+    var method: String {
+        switch self {
+        case .get:
+            return "GET"
+        }
+    }
+
+    /// ペイロード。ペイロードがないメソッドの場合は nil。
+    var body: Data? {
+        switch self {
+        case .get:
+            // GET はペイロードを取れないので nil。
+            return nil
+        }
+    }
+}

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -35,13 +35,15 @@ enum HTTPMethodAndPayload {
     case get
 
     /// POST メソッドの定義（必要になるまでは省略）。
-    // case post(payload: Data?)
+//    case post(payload: Data?)
 
     /// メソッドの文字列表現。
     var method: String {
         switch self {
         case .get:
             return "GET"
+//        case .post:
+//            return "POST"
         }
     }
 
@@ -51,6 +53,8 @@ enum HTTPMethodAndPayload {
         case .get:
             // GET はペイロードを取れないので nil。
             return nil
+//        case let .post(payload):
+//            return payload
         }
     }
 }

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import Alamofire
 
 // MARK:- Input
 /// API への入力は Request そのもの。
@@ -196,5 +197,24 @@ enum WebAPI {
             payload: data
         ))
     }
-
+    
+    // MARK: - Alamofire製のcallByAF()を実装します。
+    static func callByAF(with input: Input, _ block: @escaping (Output) -> Void) {
+        
+        let method = HTTPMethod(rawValue: input.methodAndPayload.method)
+         
+        let headers = HTTPHeaders(input.headers)
+        
+        
+        AF.request(input.url, method: method, headers: headers).response { response in
+            let output = createOutput(data: response.data, urlResponse: response.response, error: response.error)
+            block(output)
+        }.resume()
+    }
+    // ビルドを通すために callByAF 関数を用意しておく。
+    static func callByAF(with input: Input) {
+        self.call(with: input) { _ in
+            // NOTE: コールバック無しバージョンは一旦何もしない
+        }
+    }
 }

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -58,3 +58,10 @@ enum HTTPMethodAndPayload {
         }
     }
 }
+
+enum WebAPI {
+    // ビルドを通すために call 関数を用意しておく。
+    static func call(with input: Input) {
+        // TODO: もう少しインターフェースが固まったら実装する。
+    }
+}

--- a/RssReader/Model/WebAPI/WebAPI.swift
+++ b/RssReader/Model/WebAPI/WebAPI.swift
@@ -119,8 +119,33 @@ enum HTTPStatus {
 
 // MARK:- WebAPI
 enum WebAPI {
+    static func call(with input: Input, _ completion: @escaping (Output) -> Void) {
+        
+        // 実際にサーバーと通信するコードはまだはっきりしていないので、
+        // Timer を使って非同期なコード実行だけを再現する。
+        Timer.scheduledTimer(withTimeInterval: 1, repeats: false) { _ in
+            
+            // 仮のレスポンスをでっちあげる。
+            let item = Item(title: "testItem", pubDate: nil, link: "", guid: "")
+            let feed = Feed(url: "", title: "testFeed", link: "", author: "", description: "", image: "")
+            let articleList = RssArticleList(feed: feed, items: [item])
+            
+            let data = try! JSONEncoder().encode(articleList)
+            
+            let response: Response = (
+                statusCode: .ok,
+                headers: [:],
+                payload: data
+            )
+            
+            // 仮のレスポンスでコールバックを呼び出す。
+            completion(.hasResponse(response))
+        }
+    }
     // ビルドを通すために call 関数を用意しておく。
     static func call(with input: Input) {
-        // TODO: もう少しインターフェースが固まったら実装する。
+        self.call(with: input) { _ in
+            // NOTE: コールバック無しバージョンは一旦何もしない
+        }
     }
 }

--- a/RssReaderTests/RssArticleListTests.swift
+++ b/RssReaderTests/RssArticleListTests.swift
@@ -27,11 +27,8 @@ class RssArticleListTests: XCTestCase {
                 XCTAssertNotNil(article)
                 print(article.feed.title)
             }
-            
             expectation.fulfill()
         }
-        
         self.waitForExpectations(timeout: 10)
     }
-
 }

--- a/RssReaderTests/RssArticleListTests.swift
+++ b/RssReaderTests/RssArticleListTests.swift
@@ -1,0 +1,35 @@
+//
+//  RssArticleListTests.swift
+//  RssReaderTests
+//
+//  Created by 若江照仁 on 2021/05/24.
+//
+
+import XCTest
+
+class RssArticleListTests: XCTestCase {
+    func testFetch() throws {
+        let expectation = self.expectation(description: "API")
+        // 引数はurlStringだけにしたい。また、API 呼び出しは非同期なので、
+        // コールバックをとるはず（注: RssArticleList.fetch はあとで定義する）。
+        RssArticleList.fetch { errorOrArticle in
+            // エラーかレスポンスがきたらコールバックが実行されて欲しい。
+            // できれば、結果はすでに変換済みの RssArticleList オブジェクトを受け取りたい。
+            
+            switch errorOrArticle {
+            case let .left(error):
+                // エラーがきたらわかりやすいようにする。
+                XCTFail("\(error)")
+                
+            case let .right(article):
+                // 結果をきちんと受け取れたことを確認する。
+                XCTAssertNotNil(article)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 10)
+    }
+
+}

--- a/RssReaderTests/RssArticleListTests.swift
+++ b/RssReaderTests/RssArticleListTests.swift
@@ -6,13 +6,14 @@
 //
 
 import XCTest
+@testable import RssReader
 
 class RssArticleListTests: XCTestCase {
     func testFetch() throws {
         let expectation = self.expectation(description: "API")
         // 引数はurlStringだけにしたい。また、API 呼び出しは非同期なので、
         // コールバックをとるはず（注: RssArticleList.fetch はあとで定義する）。
-        RssArticleList.fetch { errorOrArticle in
+        RssArticleList.fetch(urlString: QiitaType().makeJsonUrl(tag: "swift")) { errorOrArticle in
             // エラーかレスポンスがきたらコールバックが実行されて欲しい。
             // できれば、結果はすでに変換済みの RssArticleList オブジェクトを受け取りたい。
             
@@ -24,6 +25,7 @@ class RssArticleListTests: XCTestCase {
             case let .right(article):
                 // 結果をきちんと受け取れたことを確認する。
                 XCTAssertNotNil(article)
+                print(article.feed.title)
             }
             
             expectation.fulfill()

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -29,4 +29,21 @@ class WebAPITests: XCTestCase {
         // この内容で API を呼び出す（注: WebAPI.call は後で定義する）。
         WebAPI.call(with: input)
     }
+    
+    func testResopnse() {
+        // 仮のレスポンスを定義する。
+        let response: Response = (
+            // ステータスコードは 200 OK なはず。
+            statusCode: .ok,
+            
+            // 読み取るべきヘッダーは特にない。
+            headers: [:],
+            
+            // Zen API のレスポンスは、禅なフレーズの文字列。
+            payload: "this is a response text".data(using: .utf8)!
+        )
+        
+        // TODO: このままだとペイロードが Data になってしまっていて使いづらいので、
+        // よりわかりやすいレスポンスのオブジェクトへと変換する。
+    }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -1,0 +1,16 @@
+//
+//  WebAPITests.swift
+//  RssReaderTests
+//
+//  Created by 若江照仁 on 2021/05/21.
+//
+
+import XCTest
+
+class WebAPITests: XCTestCase {
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+}

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -61,4 +61,45 @@ class WebAPITests: XCTestCase {
             XCTAssertEqual(articleList.items[0].title, "testItem")
         }
     }
+    
+    func testRequestAndResopnse() {
+        let expectation = self.expectation(description: "API を待つ")
+        let rssApiUrl = URL(string: QiitaType().makeJsonUrl(tag: "swift"))!
+        // これまでと同じようにリクエストを作成する。
+        let input: Input = (
+            url: rssApiUrl,
+            queries: [],
+            headers: [:],
+            methodAndPayload: .get
+        )
+        
+        // このリクエストで API を呼び出す。
+        // WebAPI.call の結果は、非同期なのでコールバックになるはず。
+        // また、コールバックの引数は Output 型（レスポンスありか通信エラー）になるはず。
+        // （注: WebAPI.call がコールバックを受け取れるようにするようにあとで修正する）
+        WebAPI.call(with: input) { output in
+            // サーバーからのレスポンスが帰ってきた。
+            
+            // Zen API のレスポンスの内容を確認する。
+            switch output {
+            case let .noResponse(connectionError):
+                // もし、通信エラーが起きていたらわかるようにしておく。
+                XCTFail("\(connectionError)")
+                
+                
+            case let .hasResponse(response):
+                // レスポンスがちゃんときていた場合は、わかりやすいオブジェクトへと
+                // 変換してみる。
+                let errorOrArticleList = RssArticleList.from(response: response)
+                
+                // 正しく呼び出せていれば GitHubZen が帰ってくるはずなので、
+                // 右側が nil ではなく値が入っていることを確認する。
+                XCTAssertNotNil(errorOrArticleList.right)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 10)
+    }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -62,7 +62,7 @@ class WebAPITests: XCTestCase {
         }
     }
     
-    func testRequestAndResopnse() {
+    func testRequestAndResponse() {
         let expectation = self.expectation(description: "API を待つ")
         let rssApiUrl = URL(string: QiitaType().makeJsonUrl(tag: "swift"))!
         // これまでと同じようにリクエストを作成する。

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -6,11 +6,27 @@
 //
 
 import XCTest
+@testable import RssReader
 
 class WebAPITests: XCTestCase {
 
-    func testExample() throws {
-        // This is an example of a functional test case.
-        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    func testRequest() {
+        let rssApiUrl = URL(string: QiitaType().makeJsonUrl(tag: "swift"))!
+        // リクエストを作成する。
+        let input: Request = (
+            
+            url: rssApiUrl,
+            
+            queries: [],
+            
+            // 特にヘッダーもいらない。
+            headers: [:],
+            
+            // HTTP メソッドは GET のみ対応している。
+            methodAndPayload: .get
+        )
+        
+        // この内容で API を呼び出す（注: WebAPI.call は後で定義する）。
+        WebAPI.call(with: input)
     }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -30,28 +30,35 @@ class WebAPITests: XCTestCase {
         WebAPI.call(with: input)
     }
     
-    func testResopnse() {
+    func testResponse() {
+        // 仮のデータを作ります。
+        let item = Item(title: "testItem", pubDate: nil, link: "", guid: "")
+        let feed = Feed(url: "", title: "testFeed", link: "", author: "", description: "", image: "")
+        let articleList = RssArticleList(feed: feed, items: [item])
+        
+        let data = try! JSONEncoder().encode(articleList)
+        
         // 仮のレスポンスを定義する。
         let response: Response = (
             statusCode: .ok,
             headers: [:],
-            payload: "this is a response text".data(using: .utf8)!
+            payload: data
         )
         
         // GitHubZen.from 関数を呼び出してみる。
-        let errorOrArticle = RssArticle.from(response: response)
+        let errorOrArticleList = RssArticleList.from(response: response)
         
         // 結果は、エラーか禅なフレーズのどちらか。
-        switch errorOrArticle {
+        switch errorOrArticleList {
         case let .left(error):
             // 上の仮のレスポンスであれば、エラーにはならないはず。
             // そういう場合は、XCTFail という関数でこちらにきてしまったことをわかるようにする。
             XCTFail("\(error)")
             
-        case let .right(article):
+        case let .right(articleList):
             // 上の仮のレスポンスの禅なフレーズをちゃんと読み取れたかどうか検証したい。
             // そういう場合は、XCTAssertEqual という関数で内容があっているかどうかを検証する。
-            XCTAssertEqual(article.item.title, "this is a response text")
+            XCTAssertEqual(articleList.items[0].title, "testItem")
         }
     }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -83,10 +83,8 @@ class WebAPITests: XCTestCase {
                 XCTAssertNotNil(errorOrArticleList.right)
                 print(errorOrArticleList.right!.items[0].title)
             }
-            
             expectation.fulfill()
         }
-        
         self.waitForExpectations(timeout: 10)
     }
     
@@ -105,7 +103,6 @@ class WebAPITests: XCTestCase {
                 // もし、通信エラーが起きていたらわかるようにしておく。
                 XCTFail("\(connectionError)")
                 
-                
             case let .hasResponse(response):
                 // レスポンスがちゃんときていた場合は、わかりやすいオブジェクトへと
                 // 変換してみる。
@@ -116,10 +113,8 @@ class WebAPITests: XCTestCase {
                 XCTAssertNotNil(errorOrArticleList.right)
                 print(errorOrArticleList.right!.items[0].title)
             }
-            
             expectation.fulfill()
         }
-        
         self.waitForExpectations(timeout: 10)
     }
     

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -103,4 +103,46 @@ class WebAPITests: XCTestCase {
         
         self.waitForExpectations(timeout: 10)
     }
+    
+    func testRequestAndResponseByAF() {
+        let expectation = self.expectation(description: "API を待つ")
+        let rssApiUrl = URL(string: QiitaType().makeJsonUrl(tag: "swift"))!
+        // これまでと同じようにリクエストを作成する。
+        let input: Input = (
+            url: rssApiUrl,
+            queries: [],
+            headers: [:],
+            methodAndPayload: .get
+        )
+        
+        // このリクエストで API を呼び出す。
+        // WebAPI.call の結果は、非同期なのでコールバックになるはず。
+        // また、コールバックの引数は Output 型（レスポンスありか通信エラー）になるはず。
+        // （注: WebAPI.call がコールバックを受け取れるようにするようにあとで修正する）
+        WebAPI.callByAF(with: input) { output in
+            // サーバーからのレスポンスが帰ってきた。
+            
+            // Zen API のレスポンスの内容を確認する。
+            switch output {
+            case let .noResponse(connectionError):
+                // もし、通信エラーが起きていたらわかるようにしておく。
+                XCTFail("\(connectionError)")
+                
+                
+            case let .hasResponse(response):
+                // レスポンスがちゃんときていた場合は、わかりやすいオブジェクトへと
+                // 変換してみる。
+                let errorOrArticleList = RssArticleList.from(response: response)
+                
+                // 正しく呼び出せていれば GitHubZen が帰ってくるはずなので、
+                // 右側が nil ではなく値が入っていることを確認する。
+                XCTAssertNotNil(errorOrArticleList.right)
+                print(errorOrArticleList.right!.items[0].title)
+            }
+            
+            expectation.fulfill()
+        }
+        
+        self.waitForExpectations(timeout: 10)
+    }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -33,17 +33,25 @@ class WebAPITests: XCTestCase {
     func testResopnse() {
         // 仮のレスポンスを定義する。
         let response: Response = (
-            // ステータスコードは 200 OK なはず。
             statusCode: .ok,
-            
-            // 読み取るべきヘッダーは特にない。
             headers: [:],
-            
-            // Zen API のレスポンスは、禅なフレーズの文字列。
             payload: "this is a response text".data(using: .utf8)!
         )
         
-        // TODO: このままだとペイロードが Data になってしまっていて使いづらいので、
-        // よりわかりやすいレスポンスのオブジェクトへと変換する。
+        // GitHubZen.from 関数を呼び出してみる。
+        let errorOrArticle = RssArticle.from(response: response)
+        
+        // 結果は、エラーか禅なフレーズのどちらか。
+        switch errorOrArticle {
+        case let .left(error):
+            // 上の仮のレスポンスであれば、エラーにはならないはず。
+            // そういう場合は、XCTFail という関数でこちらにきてしまったことをわかるようにする。
+            XCTFail("\(error)")
+            
+        case let .right(article):
+            // 上の仮のレスポンスの禅なフレーズをちゃんと読み取れたかどうか検証したい。
+            // そういう場合は、XCTAssertEqual という関数で内容があっているかどうかを検証する。
+            XCTAssertEqual(article.item.title, "this is a response text")
+        }
     }
 }

--- a/RssReaderTests/WebAPITests.swift
+++ b/RssReaderTests/WebAPITests.swift
@@ -95,6 +95,7 @@ class WebAPITests: XCTestCase {
                 // 正しく呼び出せていれば GitHubZen が帰ってくるはずなので、
                 // 右側が nil ではなく値が入っていることを確認する。
                 XCTAssertNotNil(errorOrArticleList.right)
+                print(errorOrArticleList.right!.items[0].title)
             }
             
             expectation.fulfill()


### PR DESCRIPTION
WebAPI 及び RssArticleListを作成
- WebAPIはpostメソッドにも対応したクライアントです。ただし、本アプリ内ではpostメソッドを使うことはありません。
- RssArticleListaは既存のstruct ArticleList にfetch関数を追加したような実装です。
- TDDで開発したのでテストも追加しています。
- URLSession, Alamofire両方実装していますが、最終的にAlamofireを使った関数を使っています。